### PR TITLE
Fix downward migration

### DIFF
--- a/updates/remove_first_and_last_names.php
+++ b/updates/remove_first_and_last_names.php
@@ -16,6 +16,10 @@ class RemoveFirstAndLastNames extends Migration
 
     public function down()
     {
-        // Nothing
+        Schema::table('users', function($table)
+        {
+            $table->string('iu_first_name', 100)->nullable();
+            $table->string('iu_last_name', 100)->nullable();
+        });
     }
 }


### PR DESCRIPTION
Fix downward migration, without these changes it throws:

![snimek obrazovky 2015-10-14 v 16 01 37](https://cloud.githubusercontent.com/assets/374917/10563704/153f042e-7595-11e5-83af-720166be793d.png)

because it wants to delete columns `iu_first_name` and `iu_last_name` in `add_profile_fields_to_users_table.php` at down() method.
