### PR TITLE
Refactor migrations and add missing fields (first name and last name)

### DIFF
--- a/updates/add_new_fields_to_users_table.php
+++ b/updates/add_new_fields_to_users_table.php
@@ -18,8 +18,7 @@ class AddNewFieldsToUsersTable extends Migration
     {
         Schema::table('users', function($table)
         {
-            $table->dropColumn('iu_telephone');
-            $table->dropColumn('iu_company');
+            $table->dropColumn(['iu_telephone', 'iu_company']);
         });
     }
 }

--- a/updates/add_profile_fields_to_users_table.php
+++ b/updates/add_profile_fields_to_users_table.php
@@ -28,16 +28,10 @@ class AddProfileFieldsToUsersTable extends Migration
     {
         Schema::table('users', function($table)
         {
-            $table->dropColumn('iu_gender');
-            $table->dropColumn('iu_job');
-            $table->dropColumn('iu_about');
-            $table->dropColumn('iu_webpage');
-            $table->dropColumn('iu_blog');
-            $table->dropColumn('iu_facebook');
-            $table->dropColumn('iu_twitter');
-            $table->dropColumn('iu_skype');
-            $table->dropColumn('iu_icq');
-            $table->dropColumn('iu_comment');
+            $table->dropColumn([
+                'iu_first_name', 'iu_last_name', 'iu_gender', 'iu_job', 'iu_about', 'iu_webpage', 'iu_blog',
+                'iu_facebook', 'iu_twitter', 'iu_skype', 'iu_icq', 'iu_comment'
+            ]);
         });
     }
 }

--- a/updates/remove_first_and_last_names.php
+++ b/updates/remove_first_and_last_names.php
@@ -9,8 +9,7 @@ class RemoveFirstAndLastNames extends Migration
     {
         Schema::table('users', function($table)
         {
-            $table->dropColumn('iu_first_name');
-            $table->dropColumn('iu_last_name');
+            $table->dropColumn(['iu_first_name', 'iu_last_name']);
         });
     }
 


### PR DESCRIPTION
When you ran `october:down`, it was left fields first name and last name in the table. Now it's fixed + refactored.